### PR TITLE
Update Command.cs

### DIFF
--- a/wServer/realm/commands/Command.cs
+++ b/wServer/realm/commands/Command.cs
@@ -27,6 +27,10 @@ namespace wServer.realm.commands
         private static int GetPermissionLevel(Player player)
         {
             if (player.Client.Account.Rank == 3)
+                return 3;
+            if (player.Client.Account.Rank == 2)
+                return 2;
+            if (player.Client.Account.Rank == 1)
                 return 1;
             return 0;
         }


### PR DESCRIPTION
Fixed rank 1, 2, and 3 the default ranks so that permissions in admincommand.cs actually affect the rank the person is.
